### PR TITLE
Fix subcontext looses value bug

### DIFF
--- a/.changeset/quick-comics-decide.md
+++ b/.changeset/quick-comics-decide.md
@@ -1,0 +1,5 @@
+---
+"orbo": patch
+---
+
+Fixed issue when listener unmounts + remounts when value has changed

--- a/packages/orbo/src/__tests__/createGlobalState.test.tsx
+++ b/packages/orbo/src/__tests__/createGlobalState.test.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from "react";
-import { fireEvent, render, waitFor } from "@testing-library/react";
+import React, { useState } from "react";
+import { fireEvent, render, waitFor, act } from "@testing-library/react";
 import { describe, test, expect, vi, afterEach } from "vitest";
 import {
   createGlobalState,
@@ -214,7 +214,9 @@ describe("Orbo - createGlobalState", () => {
       cleanupFunctions.push(cleanup);
 
       // Test state sharing
-      fireEvent.click(container.querySelector('[data-testid="button-a"]')!);
+      act(() => {
+        fireEvent.click(container.querySelector('[data-testid="button-a"]')!);
+      });
       expect(
         container.querySelector('[data-testid="count-b"]'),
       ).toHaveTextContent("B: 1");
@@ -296,7 +298,9 @@ describe("Orbo - createGlobalState", () => {
         container.querySelector('[data-testid="state-b"]'),
       ).toHaveTextContent("B");
 
-      fireEvent.click(container.querySelector('[data-testid="button-a"]')!);
+      act(() => {
+        fireEvent.click(container.querySelector('[data-testid="button-a"]')!);
+      });
 
       expect(
         container.querySelector('[data-testid="button-a"]'),
@@ -339,10 +343,14 @@ describe("Orbo - createGlobalState", () => {
 
       expect(countDisplay).toHaveTextContent("0");
 
-      fireEvent.click(button);
+      act(() => {
+        fireEvent.click(button);
+      });
       expect(countDisplay).toHaveTextContent("1");
 
-      fireEvent.click(button);
+      act(() => {
+        fireEvent.click(button);
+      });
       expect(countDisplay).toHaveTextContent("2");
     });
   });
@@ -402,17 +410,23 @@ describe("Orbo - createGlobalState", () => {
       ).toHaveTextContent("0");
 
       // First interaction: increment counter (0 → 1)
-      fireEvent.click(container.querySelector('[data-testid="increment"]')!);
+      act(() => {
+        fireEvent.click(container.querySelector('[data-testid="increment"]')!);
+      });
       expect(
         container.querySelector('[data-testid="counter"]'),
       ).toHaveTextContent("1");
 
       // Second interaction: unmount second component
-      fireEvent.click(container.querySelector('[data-testid="toggle"]')!);
+      act(() => {
+        fireEvent.click(container.querySelector('[data-testid="toggle"]')!);
+      });
       expect(container.querySelector('[data-testid="counter"]')).toBeNull();
 
       // Third interaction: remount second component
-      fireEvent.click(container.querySelector('[data-testid="toggle"]')!);
+      act(() => {
+        fireEvent.click(container.querySelector('[data-testid="toggle"]')!);
+      });
 
       // Verification: state should be reset to 0 (initialization called 2 times:
       // 1. SSR render, 2. Client hydration - state is cleaned up so no third call needed)
@@ -569,7 +583,9 @@ describe("Orbo - createGlobalState", () => {
         container.querySelector('[data-testid="theme"]'),
       ).toHaveTextContent("light");
 
-      fireEvent.click(container.querySelector('[data-testid="toggle-theme"]')!);
+      act(() => {
+        fireEvent.click(container.querySelector('[data-testid="toggle-theme"]')!);
+      });
 
       expect(
         container.querySelector('[data-testid="theme"]'),
@@ -660,11 +676,15 @@ describe("Orbo - createGlobalState", () => {
 
       // Toggle component off
       const toggleButton = container.querySelector('[data-testid="toggle"]')!;
-      fireEvent.click(toggleButton);
+      act(() => {
+        fireEvent.click(toggleButton);
+      });
       expect(container.querySelector('[data-testid="counter"]')).toBe(null);
 
       // Toggle component back on - onSubscribe should be called again since state persisted
-      fireEvent.click(toggleButton);
+      act(() => {
+        fireEvent.click(toggleButton);
+      });
       expect(
         container.querySelector('[data-testid="counter"]'),
       ).toHaveTextContent("0");
@@ -715,11 +735,15 @@ describe("Orbo - createGlobalState", () => {
       ).toHaveTextContent("42");
 
       // Unmount - cleanup should be called since no components are subscribed
-      fireEvent.click(container.querySelector('[data-testid="toggle"]')!);
+      act(() => {
+        fireEvent.click(container.querySelector('[data-testid="toggle"]')!);
+      });
       expect(cleanupSpy).toHaveBeenCalledTimes(1);
 
       // Remount - onSubscribe should be called again, state should persist
-      fireEvent.click(container.querySelector('[data-testid="toggle"]')!);
+      act(() => {
+        fireEvent.click(container.querySelector('[data-testid="toggle"]')!);
+      });
       expect(subscribeSpy).toHaveBeenCalledTimes(2); // Called again
       expect(
         container.querySelector('[data-testid="counter"]'),
@@ -873,13 +897,21 @@ describe("Orbo - createGlobalState", () => {
       };
 
       const TextComponent = () => {
-        const theme = useTheme();
         return (
           <GlobalStateProvider initialValues={{ theme: "light" }}>
+            <ParentComponent />
+          </GlobalStateProvider>
+        );
+      };
+
+      const ParentComponent = () => {
+        const theme = useTheme();
+        return (
+          <>
             <ToggleButton />
             <InitialComponent />
             {theme === "dark" && <ConditionalComponent />}
-          </GlobalStateProvider>
+          </>
         );
       };
 
@@ -887,7 +919,9 @@ describe("Orbo - createGlobalState", () => {
       const { container } = await renderAndHydrate(<TextComponent />);
 
       // emulate click on the button to change theme
-      fireEvent.click(container.querySelector('[data-testid="toggle"]')!);
+      act(() => {
+        fireEvent.click(container.querySelector('[data-testid="toggle"]')!);
+      });
 
       // wait for re-render
       await waitFor(() => {

--- a/packages/orbo/src/__tests__/createGlobalState.test.tsx
+++ b/packages/orbo/src/__tests__/createGlobalState.test.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from "react";
-import { fireEvent, render } from "@testing-library/react";
+import React, { useEffect, useState } from "react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import { describe, test, expect, vi, afterEach } from "vitest";
 import {
   createGlobalState,
@@ -844,6 +844,60 @@ describe("Orbo - createGlobalState", () => {
       ).toBeNull();
 
       expect(cleanupSpy).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("Setters work correctly across components", () => {
+    test("Reuse existing initialized context in freshly mounted new component", async () => {
+      const [useTheme, useSetTheme] = createGlobalState({
+        initialState: (context) => (context as ThemeContext).theme,
+      });
+
+      const InitialComponent = () => {
+        const theme = useTheme();
+        return <div data-testid="theme">{theme}</div>;
+      };
+
+      const ConditionalComponent = () => {
+        const theme = useTheme();
+        return <div data-testid="theme-conditional">{theme}</div>;
+      };
+
+      const ToggleButton = () => {
+        const setTheme = useSetTheme();
+        return (
+          <button data-testid="toggle" onClick={() => setTheme("dark")}>
+            Toggle Theme
+          </button>
+        );
+      };
+
+      const TextComponent = () => {
+        const theme = useTheme();
+        return (
+          <GlobalStateProvider initialValues={{ theme: "light" }}>
+            <ToggleButton />
+            <InitialComponent />
+            {theme === "dark" && <ConditionalComponent />}
+          </GlobalStateProvider>
+        );
+      };
+
+      // Context instance
+      const { container } = await renderAndHydrate(<TextComponent />);
+
+      // emulate click on the button to change theme
+      fireEvent.click(container.querySelector('[data-testid="toggle"]')!);
+
+      // wait for re-render
+      await waitFor(() => {
+        expect(
+          container.querySelector('[data-testid="theme"]'),
+        ).toHaveTextContent("dark");
+        expect(
+          container.querySelector('[data-testid="theme-conditional"]'),
+        ).toHaveTextContent("dark");
+      });
     });
   });
 });

--- a/packages/orbo/src/__tests__/createGlobalState.test.tsx
+++ b/packages/orbo/src/__tests__/createGlobalState.test.tsx
@@ -584,7 +584,9 @@ describe("Orbo - createGlobalState", () => {
       ).toHaveTextContent("light");
 
       act(() => {
-        fireEvent.click(container.querySelector('[data-testid="toggle-theme"]')!);
+        fireEvent.click(
+          container.querySelector('[data-testid="toggle-theme"]')!,
+        );
       });
 
       expect(

--- a/packages/orbo/src/index.tsx
+++ b/packages/orbo/src/index.tsx
@@ -154,13 +154,6 @@ export function createGlobalState<T>(config: GlobalStateConfig<T>) {
                 ? (newState as (prev: T) => T)(newSubContext.value)
                 : newState;
             listeners.forEach((setter) => setter(newSubContext.value));
-
-            // Update the stored value of the corresponding subContext
-            // This is important for newly mounted components using existing and initialized subContexts
-            const oldSubContext = globalStateContext?.subContexts.get(stateKey);
-            if (oldSubContext) {
-              oldSubContext.value = newSubContext.value;
-            }
           },
         cleanup: undefined,
         subscribe: (setter: (newState: any) => void) => {

--- a/packages/orbo/src/index.tsx
+++ b/packages/orbo/src/index.tsx
@@ -147,7 +147,7 @@ export function createGlobalState<T>(config: GlobalStateConfig<T>) {
         listeners,
         updateState:
           // Update state has the same shape like React's setState
-          // an can be alled in onSubscribe or by the global state setter hook
+          // an can be called in onSubscribe or by the global state setter hook
           (newState: T | ((prev: T) => T)) => {
             newSubContext.value =
               typeof newState === "function"

--- a/packages/orbo/src/index.tsx
+++ b/packages/orbo/src/index.tsx
@@ -140,23 +140,29 @@ export function createGlobalState<T>(config: GlobalStateConfig<T>) {
   ): SubContext<T> {
     let subContext = globalStateContext.subContexts.get(stateKey);
     if (!subContext) {
-      let value = config.initialState(globalStateContext.initialValues);
-      // Update state has the same shape like React's setState
-      // an can be alled in onSubscribe or by the global state setter hook
-      const updateState = (newState: T | ((prev: T) => T)) => {
-        value =
-          typeof newState === "function"
-            ? (newState as (prev: T) => T)(value)
-            : newState;
-        listeners.forEach((setter) => setter(value));
-      };
       const listeners = new Set<(newState: any) => any>();
       const newSubContext: SubContext<T> = {
         initialized: true,
-        value,
+        value: config.initialState(globalStateContext.initialValues),
         listeners,
-        updateState,
-        cleanup: onSubscribe(updateState, value),
+        updateState:
+          // Update state has the same shape like React's setState
+          // an can be alled in onSubscribe or by the global state setter hook
+          (newState: T | ((prev: T) => T)) => {
+            newSubContext.value =
+              typeof newState === "function"
+                ? (newState as (prev: T) => T)(newSubContext.value)
+                : newState;
+            listeners.forEach((setter) => setter(newSubContext.value));
+
+            // Update the stored value of the corresponding subContext
+            // This is important for newly mounted components using existing and initialized subContexts
+            const oldSubContext = globalStateContext?.subContexts.get(stateKey);
+            if (oldSubContext) {
+              oldSubContext.value = newSubContext.value;
+            }
+          },
+        cleanup: undefined,
         subscribe: (setter: (newState: any) => void) => {
           listeners.add(setter);
           return () => {
@@ -173,6 +179,10 @@ export function createGlobalState<T>(config: GlobalStateConfig<T>) {
           };
         },
       };
+      newSubContext.cleanup = onSubscribe(
+        newSubContext.updateState,
+        newSubContext.value,
+      );
       globalStateContext.subContexts.set(
         stateKey,
         newSubContext as SubContext<any>,


### PR DESCRIPTION
When rendering a second component, that uses an already initialized and modified state, the value of the second component was always the initial value. This PR fixes this bug.
Also added a test for that.