### PR TITLE
Remove impossible state checks and simplify onSubscribe initialization

### DIFF
--- a/.changeset/lemon-carpets-spend.md
+++ b/.changeset/lemon-carpets-spend.md
@@ -1,0 +1,5 @@
+---
+"orbo": minor
+---
+
+Internal code cleanup and improved test coverage for `onSubscribe` initialization

--- a/packages/orbo/src/__tests__/createGlobalState.test.tsx
+++ b/packages/orbo/src/__tests__/createGlobalState.test.tsx
@@ -881,7 +881,7 @@ describe("Orbo - createGlobalState", () => {
         onSubscribe: (updateState, initialState) => {
           updateStateSpy(initialState);
           // Call updateState directly during onSubscribe
-          // Warning such a pattern is discouraged as this pattern 
+          // Warning such a pattern is discouraged as this pattern
           // is very likely to cause hydration mismatches
           updateState("updated-from-onSubscribe");
           return () => {}; // Return cleanup function

--- a/packages/orbo/src/index.tsx
+++ b/packages/orbo/src/index.tsx
@@ -151,9 +151,9 @@ export function createGlobalState<T>(config: GlobalStateConfig<T>) {
         initialized: true,
         // Calculating the initial state on sub context creation (SSR & client)
         value: config.initialState(globalStateContext.initialValues),
+        // Update state has the same shape like React's setState
+        // an can be called in onSubscribe or by the global state setter hook
         updateState:
-          // Update state has the same shape like React's setState
-          // an can be called in onSubscribe or by the global state setter hook
           (newState: T | ((prev: T) => T)) => {
             newSubContext.value =
               typeof newState === "function"

--- a/packages/orbo/src/index.tsx
+++ b/packages/orbo/src/index.tsx
@@ -153,14 +153,13 @@ export function createGlobalState<T>(config: GlobalStateConfig<T>) {
         value: config.initialState(globalStateContext.initialValues),
         // Update state has the same shape like React's setState
         // an can be called in onSubscribe or by the global state setter hook
-        updateState:
-          (newState: T | ((prev: T) => T)) => {
-            newSubContext.value =
-              typeof newState === "function"
-                ? (newState as (prev: T) => T)(newSubContext.value)
-                : newState;
-            listeners.forEach((setter) => setter(newSubContext.value));
-          },
+        updateState: (newState: T | ((prev: T) => T)) => {
+          newSubContext.value =
+            typeof newState === "function"
+              ? (newState as (prev: T) => T)(newSubContext.value)
+              : newState;
+          listeners.forEach((setter) => setter(newSubContext.value));
+        },
         // The cleanup function is the return value of onSubscribe
         cleanup: undefined,
         listeners,

--- a/packages/orbo/src/index.tsx
+++ b/packages/orbo/src/index.tsx
@@ -152,7 +152,7 @@ export function createGlobalState<T>(config: GlobalStateConfig<T>) {
         // Calculating the initial state on sub context creation (SSR & client)
         value: config.initialState(globalStateContext.initialValues),
         // Update state has the same shape like React's setState
-        // an can be called in onSubscribe or by the global state setter hook
+        // and can be called in onSubscribe or by the global state setter hook
         updateState: (newState: T | ((prev: T) => T)) => {
           newSubContext.value =
             typeof newState === "function"

--- a/packages/orbo/src/index.tsx
+++ b/packages/orbo/src/index.tsx
@@ -144,32 +144,27 @@ export function createGlobalState<T>(config: GlobalStateConfig<T>) {
   ): SubContext<T> {
     let subContext = globalStateContext.subContexts.get(stateKey);
     if (!subContext) {
-      let value = config.initialState(globalStateContext.initialValues);
-      // Update state has the same shape like React's setState
-      // an can be alled in onSubscribe or by the global state setter hook
-      const updateState = (newState: T | ((prev: T) => T)) => {
-        const existingSubContext =
-          globalStateContext?.subContexts.get(stateKey);
-        if (!existingSubContext) {
-          return;
-        }
-        const updatedValue =
-          typeof newState === "function"
-            ? (newState as (prev: T) => T)(existingSubContext.value)
-            : newState;
-        listeners.forEach((setter) => setter(updatedValue));
-
-        // Update the stored value of the corresponding subContext
-        // This is important for newly mounted components using existing and initialized subContexts
-        existingSubContext.value = updatedValue;
-      };
       const listeners = new Set<(newState: any) => any>();
       const newSubContext: SubContext<T> = {
+        // Helper flag which is set to false after the last subscriber unmounts
+        // (needed for persistState: true)
         initialized: true,
-        value,
+        // Calculating the initial state on sub context creation (SSR & client)
+        value: config.initialState(globalStateContext.initialValues),
+        updateState:
+          // Update state has the same shape like React's setState
+          // an can be called in onSubscribe or by the global state setter hook
+          (newState: T | ((prev: T) => T)) => {
+            newSubContext.value =
+              typeof newState === "function"
+                ? (newState as (prev: T) => T)(newSubContext.value)
+                : newState;
+            listeners.forEach((setter) => setter(newSubContext.value));
+          },
+        // The cleanup function is the return value of onSubscribe
+        cleanup: undefined,
         listeners,
-        updateState,
-        cleanup: onSubscribe(updateState, value),
+        // The internal subscribe function for the orbo hooks factory
         subscribe: (setter: (newState: any) => void) => {
           listeners.add(setter);
           return () => {
@@ -186,12 +181,24 @@ export function createGlobalState<T>(config: GlobalStateConfig<T>) {
           };
         },
       };
+      // Call onSubscribe when the subcontext is created
+      // This must happen after newSubContext is fully initialized as it allows
+      // calling updateState in onSubscribe
+      newSubContext.cleanup = onSubscribe(
+        newSubContext.updateState,
+        newSubContext.value,
+      );
+      // Attach the subcontext to the GlobalState provider to ensure separate instances
+      // for multiple SSR Requests
       globalStateContext.subContexts.set(
         stateKey,
         newSubContext as SubContext<any>,
       );
       return newSubContext;
     } else if (!subContext.initialized) {
+      // Re-initialize once the first component subscribes again
+      // This is necessary if persistState is true and the last component unsubscribed
+      // as no new subcontext will be created but onSubscribe must be called again
       subContext.cleanup = onSubscribe(
         subContext.updateState,
         subContext.value,


### PR DESCRIPTION
This PR cleans up the `onSubscribe` initialization flow and removes some defensive checks that turned out to be unnecessary

The `updateState` function in the previous version had a check for `existingSubContext` before updating state. 
This check was guarding against a state that's actually impossible to reach - the subContext is always guaranteed to exist when `updateState` is called

By calling `onSubscribe` after the `newSubContext` is fully initialized (rather than before) and can't change as it is a `const` value

I've also added comments throughout to explain the initialization flow more clearly, and added a test that specifically covers calling `updateState` during `onSubscribe` to make sure this pattern works as expected (even though it can cause hydration mismatches and isn't recommended for most use cases)