### PR TITLE
add isHydrated flag

### DIFF
--- a/.changeset/sharp-words-kneel.md
+++ b/.changeset/sharp-words-kneel.md
@@ -1,0 +1,5 @@
+---
+"orbo": minor
+---
+
+Add `isHydrated` flag to initializeState

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Creates a pair of hooks for reading and writing global state.
 
 ```tsx
 const [useValue, useSetValue] = createGlobalState({
-  initialState: (initialValues) => computeInitialValue(initialValues),
+  initialState: (initialValues, isHydrated) => computeInitialValue(initialValues, isHydrated),
 
   // Optional: sync with external sources (client-side only)
   onSubscribe: (setState, currentState) => {
@@ -223,9 +223,30 @@ const [useValue, useSetValue] = createGlobalState({
 
 **Parameters:**
 
-- `config.initialState`: Function that receives initial values and returns the initial state
+- `config.initialState`: Function that receives initial values and `isHydrated` flag, returns the initial state
 - `config.onSubscribe` _(optional)_: Function called when first component subscribes (client-side only). Receives `setState` and `currentState`. Can return a cleanup function which runs when the last component unsubscribes
 - `config.persistState` _(optional)_: When `true`, keeps state in memory after components unmount (default: `true`)
+
+#### Handling Client-Only Values with `isHydrated`
+
+When working with client-only APIs like `localStorage`, `sessionStorage`, or browser APIs that aren't available during server-side rendering, there is the `isHydrated` parameter to optimize initial state handling
+
+In general it is best practices **NOT to mix SSR with client-only state** as doing so creates hydrarion mismatches issues
+
+Use the `isHydrated` flag only as a last resort when you absolutely must read from client-only APIs:
+
+```tsx
+const [useTheme] = createGlobalState({
+  initialState: (initialValues, isHydrated) => {
+    if (!isHydrated) {
+      // During SSR and initial hydration: use server value to avoid mismatch
+      return 'light';
+    }
+    // After hydration: safe to use client-only APIs
+    return localStorage.getItem('theme') || 'light';
+  }
+});
+```
 
 **Returns:**
 

--- a/packages/orbo/README.md
+++ b/packages/orbo/README.md
@@ -223,9 +223,30 @@ const [useValue, useSetValue] = createGlobalState({
 
 **Parameters:**
 
-- `config.initialState`: Function that receives initial values and returns the initial state
+- `config.initialState`: Function that receives initial values and `isHydrated` flag, returns the initial state
 - `config.onSubscribe` _(optional)_: Function called when first component subscribes (client-side only). Receives `setState` and `currentState`. Can return a cleanup function which runs when the last component unsubscribes
 - `config.persistState` _(optional)_: When `true`, keeps state in memory after components unmount (default: `true`)
+
+#### Handling Client-Only Values with `isHydrated`
+
+When working with client-only APIs like `localStorage`, `sessionStorage`, or browser APIs that aren't available during server-side rendering, there is the `isHydrated` parameter to optimize initial state handling
+
+In general it is best practices **NOT to mix SSR with client-only state** as doing so creates hydrarion mismatches issues
+
+Use the `isHydrated` flag only as a last resort when you absolutely must read from client-only APIs:
+
+```tsx
+const [useTheme] = createGlobalState({
+  initialState: (initialValues, isHydrated) => {
+    if (!isHydrated) {
+      // During SSR and initial hydration: use server value to avoid mismatch
+      return 'light';
+    }
+    // After hydration: safe to use client-only APIs
+    return localStorage.getItem('theme') || 'light';
+  }
+});
+```
 
 **Returns:**
 

--- a/packages/orbo/src/__tests__/createGlobalState.test.tsx
+++ b/packages/orbo/src/__tests__/createGlobalState.test.tsx
@@ -936,7 +936,9 @@ describe("Orbo - createGlobalState", () => {
       // During SSR and initial hydration, isHydrated should be false
       expect(capturedIsHydrated).toBe(false);
       expect(ssrHtml).toContain("test-value");
-      expect(container.querySelector('[data-testid="state"]')).toHaveTextContent("test-value");
+      expect(
+        container.querySelector('[data-testid="state"]'),
+      ).toHaveTextContent("test-value");
     });
 
     test("isHydrated becomes true after hydration completes", async () => {
@@ -944,7 +946,7 @@ describe("Orbo - createGlobalState", () => {
       const [useTestState] = createGlobalState({
         initialState: (_, isHydrated) => {
           hydrationStates.push(isHydrated);
-          return `state-${isHydrated ? 'hydrated' : 'not-hydrated'}`;
+          return `state-${isHydrated ? "hydrated" : "not-hydrated"}`;
         },
         persistState: false, // Force re-initialization when component unmounts/remounts
       });
@@ -979,7 +981,9 @@ describe("Orbo - createGlobalState", () => {
 
       // Initial state should use isHydrated: false
       expect(hydrationStates).toContain(false);
-      expect(container.querySelector('[data-testid="state"]')).toHaveTextContent("state-not-hydrated");
+      expect(
+        container.querySelector('[data-testid="state"]'),
+      ).toHaveTextContent("state-not-hydrated");
 
       // Toggle component off and on to trigger re-initialization after hydration
       act(() => {
@@ -992,7 +996,9 @@ describe("Orbo - createGlobalState", () => {
 
       // Now isHydrated should be true (because useEffect has run and updated the flag)
       expect(hydrationStates).toContain(true);
-      expect(container.querySelector('[data-testid="state"]')).toHaveTextContent("state-hydrated");
+      expect(
+        container.querySelector('[data-testid="state"]'),
+      ).toHaveTextContent("state-hydrated");
     });
   });
 

--- a/packages/orbo/src/__tests__/createGlobalState.test.tsx
+++ b/packages/orbo/src/__tests__/createGlobalState.test.tsx
@@ -911,6 +911,91 @@ describe("Orbo - createGlobalState", () => {
     });
   });
 
+  describe("isHydrated SSR/Hydration Flag", () => {
+    test("isHydrated is false during SSR and initial render", async () => {
+      let capturedIsHydrated: boolean | null = null;
+      const [useTestState] = createGlobalState({
+        initialState: (_, isHydrated) => {
+          capturedIsHydrated = isHydrated;
+          return "test-value";
+        },
+      });
+
+      const TestComponent = () => {
+        const state = useTestState();
+        return <div data-testid="state">{state}</div>;
+      };
+
+      const { container, ssrHtml, cleanup } = await renderAndHydrate(
+        <GlobalStateProvider initialValues={{}}>
+          <TestComponent />
+        </GlobalStateProvider>,
+      );
+      cleanupFunctions.push(cleanup);
+
+      // During SSR and initial hydration, isHydrated should be false
+      expect(capturedIsHydrated).toBe(false);
+      expect(ssrHtml).toContain("test-value");
+      expect(container.querySelector('[data-testid="state"]')).toHaveTextContent("test-value");
+    });
+
+    test("isHydrated becomes true after hydration completes", async () => {
+      let hydrationStates: boolean[] = [];
+      const [useTestState] = createGlobalState({
+        initialState: (_, isHydrated) => {
+          hydrationStates.push(isHydrated);
+          return `state-${isHydrated ? 'hydrated' : 'not-hydrated'}`;
+        },
+        persistState: false, // Force re-initialization when component unmounts/remounts
+      });
+
+      const TestComponent = () => {
+        const state = useTestState();
+        return <div data-testid="state">{state}</div>;
+      };
+
+      // First, create a component that will trigger re-initialization after hydration
+      const ParentComponent = () => {
+        const [showComponent, setShowComponent] = useState(true);
+        return (
+          <div>
+            <button
+              data-testid="toggle"
+              onClick={() => setShowComponent(!showComponent)}
+            >
+              Toggle
+            </button>
+            {showComponent && <TestComponent />}
+          </div>
+        );
+      };
+
+      const { container, cleanup } = await renderAndHydrate(
+        <GlobalStateProvider initialValues={{}}>
+          <ParentComponent />
+        </GlobalStateProvider>,
+      );
+      cleanupFunctions.push(cleanup);
+
+      // Initial state should use isHydrated: false
+      expect(hydrationStates).toContain(false);
+      expect(container.querySelector('[data-testid="state"]')).toHaveTextContent("state-not-hydrated");
+
+      // Toggle component off and on to trigger re-initialization after hydration
+      act(() => {
+        fireEvent.click(container.querySelector('[data-testid="toggle"]')!);
+      });
+
+      act(() => {
+        fireEvent.click(container.querySelector('[data-testid="toggle"]')!);
+      });
+
+      // Now isHydrated should be true (because useEffect has run and updated the flag)
+      expect(hydrationStates).toContain(true);
+      expect(container.querySelector('[data-testid="state"]')).toHaveTextContent("state-hydrated");
+    });
+  });
+
   describe("Setters work correctly across components", () => {
     test("Reuse existing initialized context in freshly mounted new component", async () => {
       const [useTheme, useSetTheme] = createGlobalState({

--- a/packages/orbo/src/index.tsx
+++ b/packages/orbo/src/index.tsx
@@ -25,7 +25,10 @@ export interface GlobalStateInitialValues {}
 
 interface GlobalStateConfig<T = unknown> {
   /** Function that receives the initial values from `GlobalStateProvider` and returns the initial state */
-  initialState: (globalStateInitialValues: GlobalStateInitialValues, isHydrated: boolean) => T;
+  initialState: (
+    globalStateInitialValues: GlobalStateInitialValues,
+    isHydrated: boolean,
+  ) => T;
   /**
    * Optional client side exclusive function to synchronize state with external sources
    *
@@ -159,7 +162,10 @@ export function createGlobalState<T>(config: GlobalStateConfig<T>) {
         // (needed for persistState: true)
         initialized: true,
         // Calculating the initial state on sub context creation (SSR & client)
-        value: config.initialState(globalStateContext.initialValues, globalStateContext.isHydrated),
+        value: config.initialState(
+          globalStateContext.initialValues,
+          globalStateContext.isHydrated,
+        ),
         // Update state has the same shape like React's setState
         // and can be called in onSubscribe or by the global state setter hook
         updateState: (newState: T | ((prev: T) => T)) => {


### PR DESCRIPTION
When using client-only APIs like localStorage or sessionStorage in global state, you hit a hydration mismatch problem. The server can't access these values, so if you try to use them in `initialState`, React throws hydration errors. 

So we hard code the value to match with the server rendering. This fixes the hydration errors but causes a new problem:
After the hydration when it would be save to use the correct value you will still initialize with the outdated server value instead of reading the latest value.

This PR adds an `isHydrated` boolean parameter to `initialState`. It's `false` during SSR and the initial hydration render, then becomes `true` after hydration completes. Now you can handle both cases in one place:

```tsx
const [useTheme] = createGlobalState({
  initialState: (initialValues, isHydrated) => {
    if (!isHydrated) {
      // During SSR and initial hydration: use server value to avoid mismatch
      return 'light';
    }
    // After hydration: safe to use client-only APIs
    return localStorage.getItem('theme') || 'light';
  }
});
```

> [!NOTE]  
> This will **not fix** the initial hydration problem 

For the initial hydration problem you will still need to use `onInitialize` with a `setTimeout`
