### PR TITLE
fix onSubscribe firing during partial hydration with Suspense

### DIFF
--- a/.changeset/fancy-roses-see.md
+++ b/.changeset/fancy-roses-see.md
@@ -1,0 +1,5 @@
+---
+"orbo": minor
+---
+
+Fix onSubscribe callbacks firing too early during React 19 hydration with Suspense, which caused hydration errors when syncing state with browser apis


### PR DESCRIPTION
With React 19's selective hydration, `onSubscribe` callbacks were firing during component hydration instead of after. The previous implementation set `_isHydrated = true` in GlobalStateProvider's `useEffect`, which ran before nested Suspense boundaries completed hydration. When late-hydrating components subscribed, they triggered `onSubscribe` immediately, causing hydration mismatches when syncing with browser APIs like localStorage or Broadcast API

This created a fundamental conflict: the server renders with initial state, but during hydration `onSubscribe` loads different state from localStorage before all components have hydrated, causing React to throw hydration errors

My idea is to introduce a `HydrationCheck` component nested 30 levels deep in Suspense boundaries. React's selective hydration processes Suspense boundaries from outer to inner, so deeply nesting HydrationCheck guarantees it hydrates last, even after deeply nested user Suspense boundaries (most apps use 2-5 levels max). The component uses `startTransition` to mark the hydration flag update as non-urgent, then triggers all `onSubscribe` callbacks.