### PR TITLE
Fixes an inconsistent state caused by a setState during cleanup

### DIFF
--- a/.changeset/tricky-games-glow.md
+++ b/.changeset/tricky-games-glow.md
@@ -1,0 +1,5 @@
+---
+"orbo": patch
+---
+
+Fix inconsistent state after setting a state in a component cleanup function

--- a/packages/orbo/src/index.tsx
+++ b/packages/orbo/src/index.tsx
@@ -304,10 +304,17 @@ export const createGlobalState = <T,>(config: GlobalStateConfig<T>) => {
         () => initializeSubContext(globalStateContext)._value,
       );
       // Rerender if the global state changes
-      useEffect(
-        () => initializeSubContext(globalStateContext)._subscribe(setState),
-        [],
-      );
+      useEffect(() => {
+        const subContext = initializeSubContext(globalStateContext);
+
+        // Sync state if it changed before the setState was subscribed.
+        // This occurs when the state is updated during a cleanup function of another component
+        // while this component was mounting.
+        if (state !== subContext._value) {
+          setState(subContext._value);
+        }
+        return subContext._subscribe(setState);
+      }, []);
       return state;
     },
     // Write to global state


### PR DESCRIPTION
This PR addresses an inconsistent state behavior resulting from the delay between setting the initial state of a useState hook and subscribing to updates in the useEffect function.

This can happen if a state is set during a cleanup function of a component while a new component that consumes the state is mounted.